### PR TITLE
Add Barinsta

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Table of Contents
 - [**Twire**](https://github.com/twireapp/Twire) <sup>**[[F-Droid](https://f-droid.org/app/com.perflyst.twire)]**</sup>
 - [**OctoDroid**](https://github.com/slapperwan/gh4a) <sup>**[[F-Droid](https://f-droid.org/app/com.gh4a)]**</sup>
 - [**Twidere**](https://github.com/TwidereProject/Twidere-Android) <sup>**[[F-Droid](https://f-droid.org/app/org.mariotaku.twidere)]**</sup>
-- [**Infinity-For-Reddit**](https://github.com/Docile-Alligator/Infinity-For-Reddit)
+- [**Infinity for Reddit**](https://github.com/Docile-Alligator/Infinity-For-Reddit)
+- [**Barinsta**](https://barinsta.austinhuang.me) <sup>**[[F-Droid](https://f-droid.org/app/me.austinhuang.instagrabber)]**</sup>
 
 
 ### • Contacts


### PR DESCRIPTION
Open source Instagram client.

Obviously Instagram implies NonFreeNet, but seeing you have Twitter/Reddit clients, I assume it meets the criteria.

Note that we were previously called InstaGrabber, and F-Droid still retains that name; We plan to rebrand on next stable release (it has already been done in alpha releases).

related: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/7390