### PR TITLE
Added F-Droid link to mpv-android

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Table of Contents
 
 ### • Video Player
 - [**VLC**](https://www.videolan.org/vlc/download-android.html) <sup>**[[F-Droid](https://f-droid.org/app/org.videolan.vlc)]**</sup>
-- [**mpv for Android**](https://github.com/mpv-android/mpv-android)
+- [**mpv for Android**](https://github.com/mpv-android/mpv-android) <sup>**[[F-Droid](https://f-droid.org/en/packages/is.xyz.mpv/)]**</sup>
 - [**Nova Video Player**](https://github.com/nova-video-player/aos-AVP) <sup>**[[F-Droid](https://f-droid.org/app/org.courville.nova)]**</sup>
 - [**Just (Video) Player**](https://github.com/moneytoo/Player) <sup>**[[F-Droid](https://f-droid.org/app/com.brouken.player)]**</sup>
 - [**Fermata Media Player**](https://github.com/AndreyPavlenko/Fermata)


### PR DESCRIPTION
It is seen that in the android mpv repository they have the link to fdroid: https://github.com/mpv-android/mpv-android
I think this repository is the official repository, if you go to the Play Store in the mpv-android app, you can see in the developer contact the Website option, and it redirect to that repository.