### PR TITLE
Added LibreTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Table of Contents
 - [**SkyTube**](https://github.com/ram-on/SkyTube) <sup>**[[F-Droid](https://f-droid.org/app/free.rm.skytube.oss)]**</sup>
 - [**Jellyfin**](https://github.com/jellyfin/jellyfin-android) <sup>**[[F-Droid](https://f-droid.org/app/org.jellyfin.mobile)]**</sup>
 - [**Twire**](https://github.com/twireapp/Twire) <sup>**[[F-Droid](https://f-droid.org/app/com.perflyst.twire)]**</sup>
+- [**LibreTube**](https://github.com/libre-tube/LibreTube) <sup>**[[F-Droid](https://f-droid.org/app/com.github.libretube)]**</sup>
 
 
 ### • Messaging


### PR DESCRIPTION
Alternative YouTube frontend for Android built with Piped.
For now the F-Droid link doesn't work, but probably will be availbable soon https://github.com/libre-tube/LibreTube/issues/35#issuecomment-1059193562