### PR TITLE
Add PCAPdroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Termux**](https://github.com/termux/termux-app) <sup>**[[F-Droid](https://f-droid.org/app/com.termux)]**</sup>
 * [**Auditor**](https://github.com/GrapheneOS/Auditor)
 * [**Extirpater**](https://gitlab.com/divested-mobile/extirpater) <sup>**[[F-Droid](https://www.f-droid.org/app/us.spotco.extirpater)]**</sup>
+* [**PCAPdroid**](https://github.com/emanuele-f/PCAPdroid) <sup>**[[F-Droid](https://f-droid.org/packages/com.emanuelef.remote_capture)]**</sup>
 
 ### • Text Editors
 

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Termux**](https://github.com/termux/termux-app) <sup>**[[F-Droid](https://f-droid.org/app/com.termux)]**</sup>
 * [**Auditor**](https://github.com/GrapheneOS/Auditor)
 * [**Extirpater**](https://gitlab.com/divested-mobile/extirpater) <sup>**[[F-Droid](https://www.f-droid.org/app/us.spotco.extirpater)]**</sup>
-* [**PCAPdroid**](https://github.com/emanuele-f/PCAPdroid) <sup>**[[F-Droid](https://f-droid.org/packages/com.emanuelef.remote_capture)]**</sup>
+* [**PCAPdroid**](https://github.com/emanuele-f/PCAPdroid) <sup>**[[F-Droid](https://f-droid.org/app/com.emanuelef.remote_capture)]**</sup>
 
 ### • Text Editors
 


### PR DESCRIPTION
PCAPdroid is a privacy-friendly app which lets you track, analyze and block the connections made by the other apps in your device. It also allows you to export a PCAP dump of the traffic, inspect HTTP requests/replies, decrypt TLS traffic and much more