### PR TITLE
Remove Organic Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,6 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**GMaps WV**](https://gitlab.com/divested-mobile/maps) <sup>**[[F-Droid](https://www.f-droid.org/app/us.spotco.maps)]**</sup>
 * [**μlogger**](https://github.com/bfabiszewski/ulogger-android) <sup>**[[F-Droid](https://f-droid.org/app/net.fabiszewski.ulogger)]**</sup>
 * [**OpenTopoMap Viewer**](https://github.com/Pygmalion69/OpenTopoMapViewer) <sup>**[[F-Droid](https://f-droid.org/app/org.nitri.opentopo)]**</sup>
-* [**Organic Maps**](https://github.com/organicmaps/organicmaps) <sup>**[[F-Droid](https://f-droid.org/app/app.organicmaps)]**</sup>
 * [**OsmAnd~**](http://osmand.net/) <sup>**[[F-Droid](https://f-droid.org/app/net.osmand.plus)]**</sup>
 * [**Private Location**](https://github.com/wesaphzt/privatelocation) <sup>**[[F-Droid](https://f-droid.org/app/com.wesaphzt.privatelocation)]**</sup>
 * [**Trail Sense**](https://github.com/kylecorry31/Trail-Sense) <sup>**[[F-Droid](https://f-droid.org/app/com.kylecorry.trail_sense)]**</sup>


### PR DESCRIPTION
Newer releases contain advertisement and F-Droid has downgraded to an older release (2023-09-30 ) and likely wont ship recent versions – at least for now.

#### Further information

 - https://gitlab.com/fdroid/fdroiddata/-/merge_requests/14082
 - https://github.com/organicmaps/organicmaps/issues/6668
 - https://github.com/organicmaps/organicmaps/pull/6523
 - https://f-droid.org/en/2024/01/25/twif.html
 - https://discuss.privacyguides.net/t/organic-maps-adding-kayak-referral-links-to-mobile-app/15382