### PR TITLE
Replace "unitto" with "NumberHub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 
 * [**ArityCalc**](https://github.com/woheller69/Arity) <sup>**[[F-Droid](https://f-droid.org/app/org.woheller69.arity)]**</sup>
 * [**OpenCalc**](https://github.com/Darkempire78/OpenCalc) <sup>**[[F-Droid](https://f-droid.org/app/com.darkempire78.opencalculator)]**</sup>
-* [**unitto**](https://github.com/sadellie/unitto) <sup>**[[F-Droid](https://f-droid.org/app/com.sadellie.unitto)]**</sup>
+* [**NumberHub**](https://github.com/Myzel394/NumberHub)
 * [**yetCalc**](https://github.com/Yet-Zio/yetCalc) <sup>**[[F-Droid](https://f-droid.org/app/yetzio.yetcalc)]**</sup>
 
 ### • Calendar


### PR DESCRIPTION
From the NumberHub readme:
> This app was originally created by [sadellie](https://github.com/sadellie). Unfortunately, it has been archived on March 1st, 2024 (https://github.com/sadellie/unitto) without any notice or explanation. Since there has been no activity from sadellie on GitHub since then, I guess they are not actively working on projects anymore.

The app was also archived by the project author himself on F-Droid: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/14617