### PR TITLE
Remove the unmaintained andOTP app

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,6 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 ### • Password & Authentication
 
 * [**Aegis**](https://getaegis.app/) <sup>**[[F-Droid](https://f-droid.org/app/com.beemdevelopment.aegis)]**</sup>
-* [**andOTP**](https://github.com/andOTP/andOTP) <sup>**[[F-Droid](https://f-droid.org/app/org.shadowice.flocke.andotp)]**</sup>
 * [**AuthenticatorPro**](https://github.com/jamie-mh/AuthenticatorPro)
 * [**AuthPass**](https://github.com/authpass/authpass) <sup>**[[F-Droid](https://f-droid.org/app/design.codeux.authpass.fdroid)]**</sup>
 * [**Bitwarden**](https://github.com/bitwarden/mobile)


### PR DESCRIPTION
The app has been archived and unmaintained for two years now, which is a huge security risk by its very nature. There are several other authenticator apps in this list, so `andOTP` should not be listed anymore.