### PR TITLE
Update Bitwarden repo URL with newer one

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**andOTP**](https://github.com/andOTP/andOTP) <sup>**[[F-Droid](https://f-droid.org/app/org.shadowice.flocke.andotp)]**</sup>
 * [**AuthenticatorPro**](https://github.com/jamie-mh/AuthenticatorPro)
 * [**AuthPass**](https://github.com/authpass/authpass) <sup>**[[F-Droid](https://f-droid.org/app/design.codeux.authpass.fdroid)]**</sup>
-* [**Bitwarden**](https://github.com/bitwarden/mobile)
+* [**Bitwarden**](https://github.com/bitwarden/android)
 * [**FreeOTP+**](https://github.com/helloworld1/FreeOTPPlus) <sup>**[[F-Droid](https://f-droid.org/app/org.liberty.android.freeotpplus)]**</sup>
 * [**KeePassDX**](https://github.com/Kunzisoft/KeePassDX) <sup>**[[F-Droid](https://f-droid.org/app/com.kunzisoft.keepass.libre)]**</sup>
 * [**Keyoxide**](https://codeberg.org/keyoxide/keyoxide-flutter) <sup>**[[F-Droid](https://f-droid.org/app/org.keyoxide.keyoxide)]**</sup>


### PR DESCRIPTION
Bitwarden has retired their old C# mobile app in favor of new native Kotlin Android and iOS Swift ones. This includes changes to their repo URLs, and with respect to Android: `https://github.com/bitwarden/mobile` -> `https://github.com/bitwarden/android`.