### PR TITLE
remove SkyDroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Aurora Store**](https://gitlab.com/AuroraOSS/AuroraStore) <sup>**[[F-Droid](https://f-droid.org/app/com.aurora.store)]**</sup>
 * [**IzzyOnDroid**](https://gitlab.com/sunilpaulmathew/izzyondroid) <sup>**[[F-Droid](https://f-droid.org/app/in.sunilpaulmathew.izzyondroid)]**</sup>
 * [**Obtainium**](https://github.com/ImranR98/Obtainium) <sup>**[[F-Droid](https://f-droid.org/app/dev.imranr.obtainium.fdroid)]**</sup>
-* [**Sky Droid**](https://github.com/redsolver/skydroid)
 * [**Zap.Store**](https://github.com/zapstore/zapstore)
 
 ------------------------


### PR DESCRIPTION
Remove SkyDroid for project inactivity, also the app seems to be broken, as it doesn't load the apps from the  indexes.