### PR TITLE
Change addy.io link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 
 ### • Email Aliases
 
-* [**addy.io Android**](https://gitlab.com/Stjin/anonaddy-android) <sup>**[[F-Droid](https://www.f-droid.org/app/host.stjin.anonaddy)]**</sup>
+* [**addy.io Android**](https://github.com/anonaddy/addy-android) <sup>**[[F-Droid](https://www.f-droid.org/app/host.stjin.anonaddy)]**</sup>
 * [**SimpleLogin**](https://github.com/simple-login/Simple-Login-Android) <sup>**[[F-Droid](https://www.f-droid.org/app/io.simplelogin.android.fdroid)]**</sup>
 
 ### • Email Clients


### PR DESCRIPTION
Addy.io Android moved to GitHub.
https://gitlab.com/Stjin/anonaddy-android#note-please-read