### PR TITLE
Add Tuta Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Birday**](https://github.com/m-i-n-a-r/birday) <sup>**[[F-Droid](https://f-droid.org/app/com.minar.birday)]**</sup>
 * [**Etar**](https://github.com/Etar-Group/Etar-Calendar) <sup>**[[F-Droid](https://f-droid.org/app/ws.xsoh.etar)]**</sup>
 * [**Fossify Calendar**](https://github.com/FossifyOrg/Calendar) <sup>**[[F-Droid](https://f-droid.org/app/org.fossify.calendar)]**</sup>
-* [**Tuta Calendar**](https://github.com/tutao/tutanota) <sup>**[[F-Droid](https://f-droid.org/en/packages/de.tutao.calendar/)]**</sup>
+* [**Tuta Calendar**](https://github.com/tutao/tutanota) <sup>**[[F-Droid](https://f-droid.org/app/de.tutao.calendar)]**</sup>
 
 ### • Call Blocker & Spam Filter
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Birday**](https://github.com/m-i-n-a-r/birday) <sup>**[[F-Droid](https://f-droid.org/app/com.minar.birday)]**</sup>
 * [**Etar**](https://github.com/Etar-Group/Etar-Calendar) <sup>**[[F-Droid](https://f-droid.org/app/ws.xsoh.etar)]**</sup>
 * [**Fossify Calendar**](https://github.com/FossifyOrg/Calendar) <sup>**[[F-Droid](https://f-droid.org/app/org.fossify.calendar)]**</sup>
+* [**Tuta Calendar**](https://github.com/tutao/tutanota) <sup>**[[F-Droid](https://f-droid.org/en/packages/de.tutao.calendar/)]**</sup>
 
 ### • Call Blocker & Spam Filter
 


### PR DESCRIPTION
**Title:** Add Tuta Calendar to Utilities Section  

**Description:**  
This PR adds [Tuta Calendar](https://f-droid.org/en/packages/de.tutao.calendar/) to the **Utilities** section of the README. Tuta Calendar is a privacy-focused, open-source calendar app available on F-Droid.  

**Changes:**  
- Added Tuta Calendar under the Utilities section with a link to its F-Droid page.  

