### PR TITLE
Add ProtonPass README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
     * [Music &amp; Audio Player](#-music--audio-player)
     * [Notes](#-notes)
     * [Office](#-office)
-    * [Password &amp; Authentication](#-password--authentication)
+    * [Password &amp; Authentication](#-password--auth
     * [Podcast &amp; Audio Book Player](#-podcast--audio-book-player)
     * [Privacy &amp; Security](#-privacy--security)
     * [Public Transport](#-public-transport)
@@ -642,6 +642,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**OpenKeychain**](https://github.com/open-keychain/open-keychain) <sup>**[[F-Droid](https://www.f-droid.org/app/org.sufficientlysecure.keychain)]**</sup>
 * [**Password Monitor**](https://github.com/StellarSand/Password-Monitor) <sup>**[[F-Droid](https://www.f-droid.org/app/com.password.monitor)]**</sup>
 * [**Vault**](https://github.com/arsvechkarev/Vault) <sup>**[[F-Droid](https://f-droid.org/app/com.arsvechkarev.vault)]**</sup>
+* [**ProtonPass**](https://github.com/protonpass/android-pass) <sup>**[[F-Droid](https://f-droid.org/packages/proton.android.pass.fdroid/)]**</sup>
 
 ### • Podcast & Audio Book Player
 


### PR DESCRIPTION
Proton Pass: Add "To Password and Authentication".  Mistakenly removed the word "authentication".
