### PR TITLE
Kahon app added

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 
 * [**Aniyomi**](https://github.com/aniyomiorg/aniyomi)
 * [**Bangumi**](https://github.com/czy0729/Bangumi) <sup>**[[F-Droid](https://f-droid.org/app/com.czy0729.bangumi)]**</sup>
-* [**Kahon**](https://github.com/AmanoTeam/Kahon) <sup>**[[F-Droid](https://f-droid.org/en/packages/com.amanoteam.kahon/)]**</sup>
+* [**Kahon**](https://github.com/AmanoTeam/Kahon) <sup>**[[F-Droid](https://f-droid.org/app/com.amanoteam.kahon)]**</sup>
 * [**Kotatsu**](https://github.com/nv95/Kotatsu) <sup>**[[F-Droid](https://f-droid.org/app/org.koitharu.kotatsu)]**</sup>
 * [**Nekome**](https://github.com/Chesire/Nekome) <sup>**[[F-Droid](https://f-droid.org/app/com.chesire.nekome)]**</sup>
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Aniyomi**](https://github.com/aniyomiorg/aniyomi)
 * [**Bangumi**](https://github.com/czy0729/Bangumi) <sup>**[[F-Droid](https://f-droid.org/app/com.czy0729.bangumi)]**</sup>
 * [**Kotatsu**](https://github.com/nv95/Kotatsu) <sup>**[[F-Droid](https://f-droid.org/app/org.koitharu.kotatsu)]**</sup>
-* [**Mihon**](https://github.com/mihonapp/mihon)
 * [**Nekome**](https://github.com/Chesire/Nekome) <sup>**[[F-Droid](https://f-droid.org/app/com.chesire.nekome)]**</sup>
 
 ### • Automation

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Aniyomi**](https://github.com/aniyomiorg/aniyomi)
 * [**Bangumi**](https://github.com/czy0729/Bangumi) <sup>**[[F-Droid](https://f-droid.org/app/com.czy0729.bangumi)]**</sup>
 * [**Kotatsu**](https://github.com/nv95/Kotatsu) <sup>**[[F-Droid](https://f-droid.org/app/org.koitharu.kotatsu)]**</sup>
+* [**Mihon**](https://github.com/mihonapp/mihon)
 * [**Nekome**](https://github.com/Chesire/Nekome) <sup>**[[F-Droid](https://f-droid.org/app/com.chesire.nekome)]**</sup>
 
 ### • Automation

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 
 * [**Aniyomi**](https://github.com/aniyomiorg/aniyomi)
 * [**Bangumi**](https://github.com/czy0729/Bangumi) <sup>**[[F-Droid](https://f-droid.org/app/com.czy0729.bangumi)]**</sup>
+* [**Kahon**](https://github.com/AmanoTeam/Kahon) <sup>**[[F-Droid](https://f-droid.org/en/packages/com.amanoteam.kahon/)]**</sup>
 * [**Kotatsu**](https://github.com/nv95/Kotatsu) <sup>**[[F-Droid](https://f-droid.org/app/org.koitharu.kotatsu)]**</sup>
 * [**Nekome**](https://github.com/Chesire/Nekome) <sup>**[[F-Droid](https://f-droid.org/app/com.chesire.nekome)]**</sup>
 


### PR DESCRIPTION
Mihon is a privacy-focused, open-source manga reader for Android, forked from Tachiyomi with continued development and extension support