### PR TITLE
Add Logseq to the list of applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**jtx Board**](https://github.com/TechbeeAT/jtxBoard) <sup>**[[F-Droid](https://f-droid.org/packages/at.techbee.jtx)]**</sup>
 * [**Linwood Butterfly**](https://github.com/LinwoodCloud/butterfly) <sup>**[[F-Droid](https://f-droid.org/packages/dev.linwood.butterfly.nightly)]**</sup>
 * [**Local Material Notes**](https://github.com/maelchiotti/LocalMaterialNotes) <sup>**[[F-Droid](https://f-droid.org/packages/com.maelchiotti.localmaterialnotes)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/com.maelchiotti.localmaterialnotes)]**</sup>
-* [**Logseq**](https://github.com/logseq/logseq) <sup>**[[F-Droid](https://f-droid.org/packages/com.logseq.app/)]**</sup>
+* [**Logseq**](https://github.com/logseq/logseq) <sup>**[[F-Droid](https://f-droid.org/packages/com.logseq.app)]**</sup>
 * [**Markor**](https://github.com/gsantner/markor) <sup>**[[F-Droid](https://f-droid.org/packages/net.gsantner.markor)]**</sup>
 * [**Mavinote**](https://github.com/bwqr/mavinote) <sup>**[[F-Droid](https://f-droid.org/packages/com.bwqr.mavinote)]**</sup>
 * [**Memento**](https://github.com/mwarning/Memento) <sup>**[[F-Droid](https://f-droid.org/packages/de.mwarning.memento)]**</sup>


### PR DESCRIPTION
Simply added a great app that can be used for note taking. Side note, technically can be used as a diary app too (What I use it mainly for). As it supports a journal page on the app and they also claim to be a journal app, but mainly a note taking one.