### PR TITLE
Security: Unpinned CDN Dependency for marked.js (Supply Chain Risk)

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,10 +35,10 @@
 	<main></main>
 
 	<!-- JavaScript Library to Convert Markdown into HTML -->
-	<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
 
 	<!-- Marked plugin to add heading ID's -->
-	<script src="https://cdn.jsdelivr.net/npm/marked-gfm-heading-id/lib/index.umd.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/marked-gfm-heading-id@4.1.0/lib/index.umd.js"></script>
 
 	<script>
 		// Basic Settings


### PR DESCRIPTION
## Problem

The `marked` library is loaded from jsDelivr without a pinned version (`https://cdn.jsdelivr.net/npm/marked/marked.min.js`). This means the latest version is always fetched. If the npm package is compromised or a breaking/malicious update is published, users of this page would automatically receive the compromised code.

**Severity**: `high`
**File**: `index.html`

## Solution

Pin the dependency to a specific version and add a Subresource Integrity (SRI) hash, e.g.: `<script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js" integrity="sha384-..." crossorigin="anonymous"></script>`.

## Changes

- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
