### PR TITLE
Security: Cross-Site Scripting (XSS) via unsanitized Markdown-to-HTML injection

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,9 @@
 	<!-- Marked plugin to add heading ID's -->
 	<script src="https://cdn.jsdelivr.net/npm/marked-gfm-heading-id/lib/index.umd.js"></script>
 
+	<!-- DOMPurify to sanitize parsed HTML -->
+	<script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+
 	<script>
 		// Basic Settings
 		const defaultTheme = 'darkly';
@@ -53,7 +56,7 @@
 		fetch( 'https://raw.githubusercontent.com/offa/android-foss/master/README.md' )
 			.then( response => response.text() )
 			.then( data => {
-				document.querySelector( 'main' ).innerHTML = marked.parse( data );
+				document.querySelector( 'main' ).innerHTML = DOMPurify.sanitize( marked.parse( data ) );
 			})
 			.catch( error => console.error( 'Error:', error ) );
 


### PR DESCRIPTION
## Problem

The fetched Markdown content from GitHub is parsed by `marked.parse()` and directly assigned to `innerHTML` without any sanitization (e.g., DOMPurify). The `marked` library does not sanitize embedded HTML in Markdown by default. An attacker who can modify the README.md (e.g., via a malicious pull request) could inject arbitrary HTML such as `<img src=x onerror='...'>` which would execute JavaScript in visitors' browsers.

**Severity**: `high`
**File**: `index.html`

## Solution

Sanitize the parsed HTML before injecting it into the DOM. Use DOMPurify: `document.querySelector('main').innerHTML = DOMPurify.sanitize(marked.parse(data));` and add `<script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js" integrity="..." crossorigin="anonymous"></script>`.

## Changes

- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
