### PR TITLE
Security: DOM-based XSS via unsanitized innerHTML with remote Markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,9 @@
 	<!-- JavaScript Library to Convert Markdown into HTML -->
 	<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
+	<!-- DOMPurify to sanitize HTML output -->
+	<script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+
 	<!-- Marked plugin to add heading ID's -->
 	<script src="https://cdn.jsdelivr.net/npm/marked-gfm-heading-id/lib/index.umd.js"></script>
 
@@ -53,7 +56,7 @@
 		fetch( 'https://raw.githubusercontent.com/offa/android-foss/master/README.md' )
 			.then( response => response.text() )
 			.then( data => {
-				document.querySelector( 'main' ).innerHTML = marked.parse( data );
+				document.querySelector( 'main' ).innerHTML = DOMPurify.sanitize( marked.parse( data ) );
 			})
 			.catch( error => console.error( 'Error:', error ) );
 


### PR DESCRIPTION
## Problem

The page fetches Markdown from a remote GitHub URL and renders it directly into the DOM using `innerHTML = marked.parse(data)`. The `marked` library does not sanitize HTML by default in many versions. If the remote README.md content is compromised or contains malicious HTML/JavaScript (e.g., via a compromised contributor account), arbitrary scripts could execute in visitors' browsers.

**Severity**: `high`
**File**: `index.html`

## Solution

Enable DOMPurify or a similar HTML sanitizer after marked parsing: `document.querySelector('main').innerHTML = DOMPurify.sanitize(marked.parse(data));`. Alternatively, configure marked with `{sanitize: true}` (deprecated) or use a sanitizer library like DOMPurify.

## Changes

- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
