### PR TITLE
Security: Regex with greedy quantifier on untrusted input

### DIFF
--- a/ensure_sorted.py
+++ b/ensure_sorted.py
@@ -19,7 +19,7 @@ class Category:
         self.apps = []
 
     def add_app(self, app_str: str):
-        matches = re.findall("(?<=\\[\\*\\*).*(?=\\*\\*\\])", app_str)
+        matches = re.findall("(?<=\\[\\*\\*)[^*]+(?=\\*\\*\\])", app_str)
         if len(matches) != 1:
             raise RuntimeError("These should be only one match")
         app_name = matches[0]


### PR DESCRIPTION
## Problem

The regex `(?<=\[\*\*).*(?=\*\*\])` in `add_app()` uses `.*` (greedy match) between a lookbehind and lookahead. While not a severe ReDoS risk in this specific pattern, applying it to user-contributed markdown lines (from README.md) with crafted input containing many `**]` sequences could cause slower-than-expected matching. This is a minor concern given the input source.

**Severity**: `low`
**File**: `ensure_sorted.py`

## Solution

Use a non-greedy quantifier `.*?` or a more specific character class like `[^*]+` to avoid unnecessary backtracking: `re.findall(r'(?<=\[\*\*)[^*]+(?=\*\*\])', app_str)`

## Changes

- `ensure_sorted.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
