### PR TITLE
Security: No Content Security Policy (CSP) Defined

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'unsafe-inline' https://cdn.jsdelivr.net; connect-src https://raw.githubusercontent.com; img-src 'self' https:; font-src https://cdn.jsdelivr.net;">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Android FOSS</title>
 	<link rel="stylesheet" href="">


### PR DESCRIPTION
## Problem

The HTML page loads external scripts and stylesheets from CDNs and fetches content from `raw.githubusercontent.com`, but no Content-Security-Policy is defined (neither via meta tag nor headers). This makes XSS exploitation easier if any injection vector is found.

**Severity**: `medium`
**File**: `index.html`

## Solution

Add a `<meta http-equiv="Content-Security-Policy">` tag restricting `script-src`, `style-src`, and `connect-src` to the specific CDN origins and `raw.githubusercontent.com` that are needed.

## Changes

- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
