### PR TITLE
Security: Potential IndexError When Parsing Malformed README

### DIFF
--- a/ensure_sorted.py
+++ b/ensure_sorted.py
@@ -79,6 +79,8 @@ def main():
             categories.append(category)
         # This is an app
         elif lines[i].startswith("*"):
+            if not categories:
+                raise RuntimeError("App entry found before any category header")
             # The last category in the categories list is the one we're working on
             category = categories[-1]
             category.add_app(lines[i])


### PR DESCRIPTION
## Problem

If a line starting with `*` (app entry) appears before any category header (`### •` or `## –`), `categories[-1]` will raise an `IndexError` because the `categories` list will be empty. A malformed or tampered README.md could cause the CI script to crash with an unhandled exception.

**Severity**: `low`
**File**: `ensure_sorted.py`

## Solution

Add a guard check before accessing `categories[-1]`: `if not categories: raise RuntimeError('App entry found before any category header')` or wrap in a try/except block.

## Changes

- `ensure_sorted.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
