### PR TITLE
Security: DOM-based Theme Injection via Unsanitized Input in Template Literal

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,8 +58,11 @@
 			.catch( error => console.error( 'Error:', error ) );
 
 		// Change the theme
+		const allowedThemes = ['darkly', 'united', 'flatly', 'quartz'];
+
 		function changeCSS( theme )
 		{
+			if ( !allowedThemes.includes( theme ) ) return;
 			document.querySelector( 'link' ).href
 					= `https://cdn.jsdelivr.net/npm/bootswatch@${bootswatchVersion}/dist/${theme}/bootstrap.min.css`;
 		}


### PR DESCRIPTION
## Problem

The `changeCSS()` function directly interpolates its `theme` parameter into a URL template literal without validation. While currently called only from a `<select>` element with fixed `<option>` values, if invoked programmatically with a crafted value (e.g., via browser console or future code changes), it could load an arbitrary external stylesheet by manipulating the URL path.

**Severity**: `low`
**File**: `index.html`

## Solution

Validate the `theme` parameter against an allowlist of known theme names before constructing the URL: `const allowedThemes = ['darkly', 'united', 'flatly', 'quartz']; if (!allowedThemes.includes(theme)) return;`.

## Changes

- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
