### PR TITLE
Security: Unpinned CDN dependency versions allow supply chain attacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,10 +35,10 @@
 	<main></main>
 
 	<!-- JavaScript Library to Convert Markdown into HTML -->
-	<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
 
 	<!-- Marked plugin to add heading ID's -->
-	<script src="https://cdn.jsdelivr.net/npm/marked-gfm-heading-id/lib/index.umd.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/marked-gfm-heading-id@3.2.0/lib/index.umd.js"></script>
 
 	<script>
 		// Basic Settings


### PR DESCRIPTION
## Problem

The `marked` and `marked-gfm-heading-id` libraries are loaded from jsdelivr without pinned versions (`/npm/marked/marked.min.js` and `/npm/marked-gfm-heading-id/lib/index.umd.js`). This means the CDN serves whatever the latest version is, which could change at any time. A malicious version published to npm would be automatically served to all visitors.

**Severity**: `medium`
**File**: `index.html`

## Solution

Pin both libraries to specific versions, e.g., `https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js` and add SRI hashes.

## Changes

- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
