### PR TITLE
Security: Terminal escape sequence injection via crafted app names

### DIFF
--- a/ensure_sorted.py
+++ b/ensure_sorted.py
@@ -23,6 +23,7 @@ class Category:
         if len(matches) != 1:
             raise RuntimeError("These should be only one match")
         app_name = matches[0]
+        app_name = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', app_name)
         # make it lower case and append it
         self.apps.append(app_name.lower())
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
 		fetch( 'https://raw.githubusercontent.com/offa/android-foss/master/README.md' )
 			.then( response => response.text() )
 			.then( data => {
+				data = data.replace( /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g, '' );
 				document.querySelector( 'main' ).innerHTML = marked.parse( data );
 			})
 			.catch( error => console.error( 'Error:', error ) );


### PR DESCRIPTION
## Problem

In `ensure_sorted.py`, app names are extracted from `README.md` via regex and printed directly to the terminal interspersed with ANSI escape codes. If a malicious contributor inserts crafted escape sequences within app name fields in the Markdown (e.g., `[**\x1b]malicious\x1b\\**]`), they could potentially manipulate terminal output, hide malicious changes, or in some terminals execute commands.

**Severity**: `low`
**File**: `ensure_sorted.py`

## Solution

Sanitize extracted app names before printing to the terminal by stripping or escaping non-printable and control characters, e.g., `app_name = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', app_name)`.

## Changes

- `ensure_sorted.py` (modified)
- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
