### PR TITLE
Security: Third-party JavaScript loaded from CDN without version pinning or SRI

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,10 +36,10 @@
 	<main></main>
 
 	<!-- JavaScript Library to Convert Markdown into HTML -->
-	<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" integrity="sha384-Bs4kP6I8rZlHppZArYrusS4x+h0/pk3jfbQ3VIAtF5NCz7L+G2kZZgwyU0YJIUKc" crossorigin="anonymous"></script>
 
 	<!-- Marked plugin to add heading ID's -->
-	<script src="https://cdn.jsdelivr.net/npm/marked-gfm-heading-id/lib/index.umd.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/marked-gfm-heading-id@4.1.1/lib/index.umd.js" integrity="sha384-lx9H9n1tFoZT3zh0+BTtPlqvGjYH6G+jD/adJzi10BGSAdoo6gWQBaIj++ImQxGc" crossorigin="anonymous"></script>
 
 	<script>
 		// Basic Settings


### PR DESCRIPTION
## Summary

Security: Third-party JavaScript loaded from CDN without version pinning or SRI

## Problem

**Severity**: `High` | **File**: `index.html:L39`

External scripts are loaded from jsDelivr without Subresource Integrity (`integrity` + `crossorigin`) and at least one URL is not version-pinned (`marked.min.js`). If the CDN or dependency supply chain is compromised, malicious JavaScript can be executed in clients.

## Solution

Pin exact dependency versions in script URLs and add SRI hashes. Prefer self-hosting vetted copies for stronger supply-chain control.

## Changes

- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced