### PR TITLE
Security: Rendering mutable remote content from branch head

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 		marked.use( markedGfmHeadingId.gfmHeadingId() );
 
 		// Get the markdown file, convert it to HTML & put it inside the main tag
-		fetch( 'https://raw.githubusercontent.com/offa/android-foss/master/README.md' )
+		fetch( 'README.md' )
 			.then( response => response.text() )
 			.then( data => {
 				document.querySelector( 'main' ).innerHTML = marked.parse( data );


### PR DESCRIPTION
## Summary

Security: Rendering mutable remote content from branch head

## Problem

**Severity**: `Medium` | **File**: `index.html:L54`

The app fetches Markdown from `.../master/README.md`, which is a mutable branch reference. Content can change at any time and is immediately rendered client-side. This increases risk of unexpected content/script injection and makes output non-reproducible.

## Solution

Fetch content from a pinned commit SHA or signed release artifact instead of a moving branch. Combine with sanitization and strict CSP to limit impact if remote content changes.

## Changes

- `index.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced