### PR TITLE
Add ShizuCallRecorder to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**RustDesk**](https://github.com/rustdesk/rustdesk) <sup>**[[F-Droid](https://f-droid.org/packages/com.carriez.flutter_hbb)]**</sup>
 * [**Simple Time Tracker**](https://github.com/Razeeman/Android-SimpleTimeTracker) <sup>**[[F-Droid](https://f-droid.org/packages/com.razeeman.util.simpletimetracker)]**</sup>
 * [**Stay Put**](https://codeberg.org/y20k/stayput) <sup>**[[F-Droid](https://f-droid.org/packages/org.y20k.stayput)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/org.y20k.stayput)]**</sup>
+* [**ShizuCallRecorder**](https://github.com/kitsumed/ShizuCallRecorder)
 * [**Timeto.me**](https://github.com/Medvedev91/timeto.me) <sup>**[[F-Droid](https://f-droid.org/packages/me.timeto.app)]**</sup>
 * [**Whisper**](https://github.com/woheller69/whisperIME) <sup>**[[F-Droid](https://f-droid.org/packages/org.woheller69.whisper)]**</sup>
 

--- a/README.md
+++ b/README.md
@@ -588,9 +588,9 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Motion Eye**](https://github.com/JairajJangle/motioneye-android) <sup>**[[F-Droid](https://f-droid.org/packages/com.jairaj.janglegmail.motioneye)]**</sup>
 * [**Openreads**](https://github.com/mateusz-bak/openreads) <sup>**[[F-Droid](https://f-droid.org/packages/software.mdev.bookstracker)]**</sup>
 * [**RustDesk**](https://github.com/rustdesk/rustdesk) <sup>**[[F-Droid](https://f-droid.org/packages/com.carriez.flutter_hbb)]**</sup>
+* [**ShizuCallRecorder**](https://github.com/kitsumed/ShizuCallRecorder)
 * [**Simple Time Tracker**](https://github.com/Razeeman/Android-SimpleTimeTracker) <sup>**[[F-Droid](https://f-droid.org/packages/com.razeeman.util.simpletimetracker)]**</sup>
 * [**Stay Put**](https://codeberg.org/y20k/stayput) <sup>**[[F-Droid](https://f-droid.org/packages/org.y20k.stayput)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/org.y20k.stayput)]**</sup>
-* [**ShizuCallRecorder**](https://github.com/kitsumed/ShizuCallRecorder)
 * [**Timeto.me**](https://github.com/Medvedev91/timeto.me) <sup>**[[F-Droid](https://f-droid.org/packages/me.timeto.app)]**</sup>
 * [**Whisper**](https://github.com/woheller69/whisperIME) <sup>**[[F-Droid](https://f-droid.org/packages/org.woheller69.whisper)]**</sup>
 


### PR DESCRIPTION
FOSS app, release process is currently ran with Github Runners Actions and attested before release.

Allow to record phone call on most Android 11-16 devices by using ADB (Shizuku).

https://github.com/kitsumed/ShizuCallRecorder

https://www.reddit.com/r/fossdroid/comments/1tgxi0e/shizucallrecorder_record_phone_call_on_android/