### PR TITLE
Update BlissLauncher project URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 
 ### • Launcher & Desktop
 
-* [**BlissLauncher**](https://gitlab.e.foundation/e/apps/BlissLauncher) <sup>**[[F-Droid](https://f-droid.org/packages/foundation.e.blisslauncher)]**</sup>
+* [**BlissLauncher**](https://gitlab.e.foundation/e/os/BlissLauncher3)
 * [**CCLauncher**](https://github.com/mlm-games/cclauncher) <sup>**[[F-Droid](https://f-droid.org/packages/app.cclauncher)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/app.cclauncher)]**</sup>
 * [**Discreet Launcher**](https://github.com/falzonv/discreet-launcher) <sup>**[[F-Droid](https://f-droid.org/packages/com.vincent_falzon.discreetlauncher)]**</sup>
 * [**Easy Launcher**](https://github.com/DroidWorksStudio/EasyLauncher) <sup>**[[F-Droid](https://f-droid.org/packages/app.easy.launcher)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/app.easy.launcher)]**</sup>


### PR DESCRIPTION
BlissLauncher does not have a F-Droid link anymore and is no longer maintained.  

There is a new version of it called BlissLauncher3, however this does not have a F-Droid link.