### PR TITLE
Add Nudge to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 ### • Productivity
 
 * [**Flux**](https://github.com/chindaronit/Flux) <sup>**[[F-Droid](https://f-droid.org/packages/com.flux)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/fdroid/index/apk/com.flux)]**</sup>
+* [**Nudge**](https://github.com/astraedus/nudge)
 
 ### • Public Transport
 


### PR DESCRIPTION
Adds [Nudge](https://github.com/astraedus/nudge) under Productivity.

Nudge is a privacy-first, open-source app blocker for Android (delay-to-open, reel/click counters, per-app time budgets, breathing exercise, block YouTube Shorts).

It meets the inclusion criteria:
- Licensed FOSS (GPL-3.0), source available on GitHub
- Keeps privacy, no ads, no spyware, and **zero internet permission** (it literally cannot phone home)
- No proprietary elements
- Stable and actively maintained
- Documentation available (README + project website)
- Free of charge

Linked as project-page-only per the contributing format (not yet on F-Droid/IzzyOnDroid; no Play Store link included, per guidelines).