### PR TITLE
Adds OpenHearing to Sports & Health (alphabetically, before OpenTracks — alongside hEARtest, where hearing apps live)

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**hEARtest**](https://github.com/woheller69/audiometry) <sup>**[[F-Droid](https://f-droid.org/packages/org.woheller69.audiometry)]**</sup>
 * [**Meditation**](https://github.com/nyxkn/meditation) <sup>**[[F-Droid](https://f-droid.org/packages/com.nyxkn.meditation)]**</sup>
 * [**MedTimer**](https://github.com/Futsch1/medTimer) <sup>**[[F-Droid](https://f-droid.org/packages/com.futsch1.medtimer)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/com.futsch1.medtimer)]**</sup>
+* [**OpenHearing**](https://github.com/HMAKT99/OpenHearing)
 * [**OpenTracks**](https://github.com/OpenTracksApp/OpenTracks) <sup>**[[F-Droid](https://f-droid.org/packages/de.dennisguse.opentracks)]**</sup>
 * [**Paseo**](https://gitlab.com/pardomi/paseo) <sup>**[[F-Droid](https://f-droid.org/packages/ca.chancehorizon.paseo)]**</sup>
 * [**Red Moon**](https://github.com/LibreShift/red-moon) <sup>**[[F-Droid](https://f-droid.org/packages/com.jmstudios.redmoon)]**</sup>


### PR DESCRIPTION
OpenHearing (https://github.com/HMAKT99/OpenHearing) is open-source hearing assistance for Android: a pure-tone hearing screening, an audiogram-based amplification profile, and real-time amplification of quiet speech — works with any earbuds.
 
  Why it fits:
  - FOSS — GPLv3, full source public.
  - Privacy, platform-enforced — declares no INTERNET permission, so it cannot make any network calls; no ads, analytics, or trackers; everything runs on-device. Verify with aapt dump permissions.
  - No proprietary components — no Google Play Services / Firebase.
  - Documented & maintained — full README with screenshots, architecture & safety docs, CI, and a signed release (v0.1.0-alpha01).
  - Free of charge.
  
 Not yet on F-Droid/IzzyOnDroid — listed with the GitHub link per the guidelines for apps not yet on app repositories.