### PR TITLE
Add ForestMate (Sports & Health)

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Feeel**](https://gitlab.com/enjoyingfoss/feeel) <sup>**[[F-Droid](https://f-droid.org/packages/com.enjoyingfoss.feeel)]**</sup>
 * [**FitoTrack**](https://codeberg.org/jannis/FitoTrack) <sup>**[[F-Droid](https://f-droid.org/packages/de.tadris.fitness)]**</sup>
 * [**Flexify**](https://github.com/brandonp2412/Flexify) <sup>**[[F-Droid](https://f-droid.org/packages/com.presley.flexify)]**</sup>
+* [**ForestMate**](https://github.com/spcx0701/forest-mate)
 * [**hEARtest**](https://github.com/woheller69/audiometry) <sup>**[[F-Droid](https://f-droid.org/packages/org.woheller69.audiometry)]**</sup>
 * [**Meditation**](https://github.com/nyxkn/meditation) <sup>**[[F-Droid](https://f-droid.org/packages/com.nyxkn.meditation)]**</sup>
 * [**MedTimer**](https://github.com/Futsch1/medTimer) <sup>**[[F-Droid](https://f-droid.org/packages/com.futsch1.medtimer)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/com.futsch1.medtimer)]**</sup>


### PR DESCRIPTION
Adds **[ForestMate](https://github.com/spcx0701/forest-mate)** to *Sports & Health*.

ForestMate is a hiking safety companion for Android (Kotlin) with a Wear OS companion app. It combines Korean forest/weather public data with a safety index, trail risk alerts, offline fallback, and one-tap SOS.

Criteria check:
- License: Apache-2.0 (FOSS), source in the linked repository (Android app under `packaging/android`, server + web client included and self-hostable)
- Privacy: no ads, no tracking SDKs (no Firebase/Crashlytics/Play Services/AdMob)
- Stable and actively developed: v1.4.2 released 2026-07-01, regular releases
- Documentation: project website https://forestmate.app and README (ko/en)
- Free of charge
- Note: the default build talks to the hosted API at forestmate.app (F-Droid *NonFreeNet* applies; F-Droid inclusion is prepared but not yet published, hence project-page-only link format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)