### PR TITLE
Add OpenHabitTracker to Habit Tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Grit**](https://github.com/shub39/Grit) <sup>**[[F-Droid](https://f-droid.org/packages/com.shub39.grit)]**</sup>
 * [**Habit-Maker**](https://github.com/dessalines/habit-maker) <sup>**[[F-Droid](https://f-droid.org/packages/com.dessalines.habitmaker)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/fdroid/index/apk/com.dessalines.habitmaker)]**</sup>
 * [**Loop Habit Tracker**](https://github.com/iSoron/uhabits) <sup>**[[F-Droid](https://f-droid.org/packages/org.isoron.uhabits)]**</sup>
+* [**OpenHabitTracker**](https://github.com/Jinjinov/OpenHabitTracker)
 * [**SkillApp**](https://github.com/Jaimies/SkillApp) <sup>**[[F-Droid](https://f-droid.org/packages/com.theskillapp.skillapp)]**</sup>
 * [**Sobriety**](https://github.com/KiARC/Sobriety) <sup>**[[F-Droid](https://f-droid.org/packages/com.katiearose.sobriety)]**</sup>
 * [**Table Habit**](https://github.com/FriesI23/mhabit) <sup>**[[F-Droid](https://f-droid.org/packages/io.github.friesi23.mhabit)]**</sup>


### PR DESCRIPTION
OpenHabitTracker takes notes, plans tasks and tracks habits. GPL-3.0, no ads, no tracking, no account, all data stored on the device, actively developed, documented at https://openhabittracker.net.

It is not on F-Droid (built with .NET MAUI, which F-Droid's servers cannot build), so the entry links the project page only.
