### PR TITLE
Add LANShield

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**AFWall+**](https://github.com/ukanth/afwall) <sup>**[[F-Droid](https://f-droid.org/packages/dev.ukanth.ufirewall)]**</sup>
 * [**De1984**](https://github.com/dorumrr/de1984) <sup>**[[F-Droid](https://f-droid.org/packages/io.github.dorumrr.de1984)]**</sup>
 * [**Karma Firewall**](https://github.com/nightflame2/karma-firewall) <sup>**[[F-Droid](https://f-droid.org/packages/net.stargw.fok)]**</sup>
+* [**LANShield**](https://github.com/DistriNet/LANShield) <sup>**[[F-Droid](https://f-droid.org/packages/org.distrinet.lanshield)]**</sup>
 * [**NetGuard**](https://github.com/M66B/NetGuard) <sup>**[[F-Droid](https://f-droid.org/packages/eu.faircode.netguard)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/eu.faircode.netguard)]**</sup>
 * [**Rethink DNS + Firewall**](https://github.com/celzero/rethink-app) <sup>**[[F-Droid](https://f-droid.org/packages/com.celzero.bravedns)]**</sup>
 


### PR DESCRIPTION
Adds [LANShield](https://github.com/DistriNet/LANShield) to Firewalls

The app gives users insight into network traffic from individual apps to devices on their LAN, lets users block/allow LAN access per app, and can detect apps listening on open ports.

 Criteria:
  - Licensed as Free and Open Source Software: [Apache 2.0](https://github.com/DistriNet/LANShield/blob/main/LICENSE)
  - Source code available: Yes, [public git repo](https://github.com/DistriNet/LANShield/)
  - Keeps Privacy – No Advertisement, no Spyware! Yes
  - No proprietary elements: By default, yes. For the Play Store build, crashlytics is added
  - Stable (at least stable to use): Yes
  - Actively developed, maintained or supported: Yes, see [git commit history](https://github.com/DistriNet/LANShield/commits/main/)
  - Documentation available (Project website etc.): Yes, git [README](https://github.com/DistriNet/LANShield/blob/main/README.md) and [website](https://lanshield.eu)
  - Free of charge: Yes. Funded by [NLnet / NGI0 Core](https://nlnet.nl/project/LocalShield/)