### PR TITLE
Add Codecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 ### • Automation
 
 * [**Automation**](https://git.server47.de/jens/Automation) <sup>**[[F-Droid](https://f-droid.org/packages/com.jens.automation2)]**</sup>
+* [**Codecks**](https://github.com/vaddisrinivas/codecks)
 * [**Dicio**](https://github.com/Stypox/dicio-android) <sup>**[[F-Droid](https://f-droid.org/packages/org.stypox.dicio)]**</sup>
 * [**Home Assistant**](https://github.com/home-assistant/android) <sup>**[[F-Droid](https://f-droid.org/packages/io.homeassistant.companion.android.minimal)]**</sup>
 * [**Smart AutoClicker**](https://github.com/Nain57/Smart-AutoClicker) <sup>**[[F-Droid](https://f-droid.org/packages/com.buzbuz.smartautoclicker)]**</sup>


### PR DESCRIPTION
Adds Codecks, an Apache-2.0 Android app for local-first Mac automation from Android.\n\nIt provides a command deck, Bluetooth HID trackpad, and reviewable automations, with no account requirement and visible privacy/security docs in the repository.