### PR TITLE
Add WonderFood

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**OpenTracks**](https://github.com/OpenTracksApp/OpenTracks) <sup>**[[F-Droid](https://f-droid.org/packages/de.dennisguse.opentracks)]**</sup>
 * [**Paseo**](https://gitlab.com/pardomi/paseo) <sup>**[[F-Droid](https://f-droid.org/packages/ca.chancehorizon.paseo)]**</sup>
 * [**Red Moon**](https://github.com/LibreShift/red-moon) <sup>**[[F-Droid](https://f-droid.org/packages/com.jmstudios.redmoon)]**</sup>
+* [**WonderFood**](https://github.com/vaddisrinivas/wonderfood)
 
 ### • Synchronisation
 


### PR DESCRIPTION
Adds WonderFood, an Apache-2.0 Android food workspace for local-first inventory, recipes, meal planning, shopping, receipts, and reviewable AI proposals.\n\nThe repository documents its FOSS flavor, which builds without the optional Google Drive and Health Connect integrations from the Play flavor.