### PR TITLE
Add Money Manager Ex for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**CryptoTracker**](https://github.com/judemont/cryptotracker) <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/jdm.apps.cryptotracker)]**</sup>
 * [**Currencies**](https://github.com/sal0max/currencies) <sup>**[[F-Droid](https://f-droid.org/packages/de.salomax.currencies)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/de.salomax.currencies)]**</sup>
 * [**GreenStash**](https://github.com/Pool-Of-Tears/GreenStash) <sup>**[[F-Droid](https://f-droid.org/packages/com.starry.greenstash)]**</sup>
-* [**Money Manager Ex**](https://github.com/moneymanagerex/android-money-manager-ex)<sup>**[[F-Droid](https://f-droid.org/en/packages/com.money.manager.ex/)]**</sup>
+* [**Money Manager Ex**](https://github.com/moneymanagerex/android-money-manager-ex)<sup>**[[F-Droid](https://f-droid.org/packages/com.money.manager.ex)]**</sup>
 * [**My Expenses**](https://github.com/mtotschnig/MyExpenses) <sup>**[[F-Droid](https://f-droid.org/packages/org.totschnig.myexpenses)]**</sup>
 * [**Oinkoin**](https://github.com/emavgl/oinkoin) <sup>**[[F-Droid](https://f-droid.org/packages/com.github.emavgl.piggybankpro)]**</sup>
 * [**Recurring Expense Tracker**](https://github.com/DennisBauer/RecurringExpenseTracker) <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/de.dbauer.expensetracker)]**</sup>

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**CryptoTracker**](https://github.com/judemont/cryptotracker) <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/jdm.apps.cryptotracker)]**</sup>
 * [**Currencies**](https://github.com/sal0max/currencies) <sup>**[[F-Droid](https://f-droid.org/packages/de.salomax.currencies)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/de.salomax.currencies)]**</sup>
 * [**GreenStash**](https://github.com/Pool-Of-Tears/GreenStash) <sup>**[[F-Droid](https://f-droid.org/packages/com.starry.greenstash)]**</sup>
+* [**Money Manager Ex**](https://github.com/moneymanagerex/android-money-manager-ex)<sup>**[[F-Droid](https://f-droid.org/en/packages/com.money.manager.ex/)]**</sup>
 * [**My Expenses**](https://github.com/mtotschnig/MyExpenses) <sup>**[[F-Droid](https://f-droid.org/packages/org.totschnig.myexpenses)]**</sup>
 * [**Oinkoin**](https://github.com/emavgl/oinkoin) <sup>**[[F-Droid](https://f-droid.org/packages/com.github.emavgl.piggybankpro)]**</sup>
 * [**Recurring Expense Tracker**](https://github.com/DennisBauer/RecurringExpenseTracker) <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/de.dbauer.expensetracker)]**</sup>


### PR DESCRIPTION
1. Money Manager Ex Android is under [GPL-3.0 License](https://github.com/moneymanagerex/android-money-manager-ex?tab=GPL-3.0-1-ov-file) ([Desktop is under GPL-2.0](https://github.com/moneymanagerex/moneymanagerex?tab=GPL-2.0-1-ov-file))
2. [Source Code available](https://github.com/moneymanagerex/android-money-manager-ex)
3. [Analytics is optional and data sent is anonymous](https://android.moneymanagerex.org/usermanual/settings/#:~:text=Send%20Anonymous%20usage%20data%3A%20this%20allows%20sending%20anonymous%20usage%20statistics%20from%20your%20device). Financial data is locally stored but user can use [their own cloud service provider](https://moneymanagerex.org/docs/features/usecloud/). On top of that, said financial data is [encrypted](https://moneymanagerex.org/docs/features/security/#:~:text=Android%20App%3A%20Utilizes%20robust%20AES256%20encryption%20to%20protect%20your%20data%20on%20the%20go) and users **may** add a password if they so desire. 
4. Possibly no proprietary elements
5. It is mostly stable
6. Still in active development since at least [2014](https://github.com/moneymanagerex/android-money-manager-ex/releases?page=33#release-1.4.9) or earlier
7. Has a [user manual](https://android.moneymanagerex.org/usermanual/) listed in their github page and website
8. [Free of charge](https://android.moneymanagerex.org/#:~:text=free%2C%20open%2Dsource)
