### PR TITLE
Add SMS Resend to SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,6 +777,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Fossify SMS Messenger**](https://github.com/FossifyOrg/Messages) <sup>**[[F-Droid](https://f-droid.org/packages/org.fossify.messages)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/org.fossify.messages)]**</sup>
 * [**Messages**](https://github.com/PVOT-OSS/Messages) <sup>**[[F-Droid](https://f-droid.org/packages/org.prauga.messages)]**</sup>
 * [**Quik**](https://github.com/octoshrimpy/quik) <sup>**[[F-Droid](https://f-droid.org/packages/dev.octoshrimpy.quik.fdroid)]**</sup>
+* [**SMS Resend**](https://github.com/Stmol/sms-to-telegram-android-app)
 
 ### • Sports & Health
 


### PR DESCRIPTION
Adds SMS Resend to the SMS category.

Project page only for now: it is MIT-licensed, source-available, and currently distributed via GitHub/sideloading only.