### PR TITLE
Add FluxDown to Downloader & Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Aria2App**](https://github.com/devgianlu/Aria2App) <sup>**[[F-Droid](https://f-droid.org/packages/com.gianlu.aria2app)]**</sup>
 * [**Download Navi**](https://github.com/TachibanaGeneralLaboratories/download-navi) <sup>**[[F-Droid](https://f-droid.org/packages/com.tachibana.downloader)]**</sup>
 * [**dvd**](https://github.com/yausername/dvd) <sup>**[[F-Droid](https://f-droid.org/packages/org.yausername.dvd)]**</sup>
+* [**FluxDown**](https://github.com/zerx-lab/FluxDown)
 * [**Gopeed**](https://github.com/GopeedLab/gopeed)
 * [**LibreTorrent**](https://github.com/proninyaroslav/libretorrent) <sup>**[[F-Droid](https://f-droid.org/packages/org.proninyaroslav.libretorrent)]**</sup>
 * [**Myne**](https://github.com/Pool-Of-Tears/Myne) <sup>**[[F-Droid](https://f-droid.org/packages/com.starry.myne)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/com.starry.myne)]**</sup>


### PR DESCRIPTION
FluxDown is a multi-protocol download manager (HTTP/HTTPS, FTP, BitTorrent, eD2K, HLS, DASH) with an Android build alongside the desktop ones.

Checking it against the criteria:

- License: AGPL-3.0, source at https://github.com/zerx-lab/FluxDown
- No ads, no trackers, no account required — everything stays on device
- No proprietary components: the Android build pulls in no Google Play Services, Firebase or Crashlytics
- Free of charge, actively developed, docs at https://fluxdown.zerx.dev

It is not on F-Droid or IzzyOnDroid yet, so I left the entry as a plain project link like the Gopeed entry above. I will send a follow-up to add the badge once it is packaged.