### PR TITLE
Add Chompass to Sports & Health

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 ### • Sports & Health
 
 * [**Box, Box!**](https://github.com/BrightDV/BoxBox) <sup>**[[F-Droid](https://f-droid.org/packages/org.brightdv.boxbox)]**</sup>
+* [**Chompass**](https://codeberg.org/fitguy/chompass)
 * [**Feeel**](https://gitlab.com/enjoyingfoss/feeel) <sup>**[[F-Droid](https://f-droid.org/packages/com.enjoyingfoss.feeel)]**</sup>
 * [**FitoTrack**](https://codeberg.org/jannis/FitoTrack) <sup>**[[F-Droid](https://f-droid.org/packages/de.tadris.fitness)]**</sup>
 * [**Flexify**](https://github.com/brandonp2412/Flexify) <sup>**[[F-Droid](https://f-droid.org/packages/com.presley.flexify)]**</sup>


### PR DESCRIPTION
Closes #706

Adds [Chompass](https://codeberg.org/fitguy/chompass) under Sports & Health.

- MIT, source on Codeberg
- No ads / no analytics
- Local-first diary; optional BYOK AI (not required for logging)
- Website: https://chompass.app/
- F-Droid: pending (`app.chompass`) can add the F-Droid link later when indexed