### PR TITLE
Add Granular Volume: Quiet Dial (Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**DeadHash**](https://github.com/CodeDead/DeadHash-android) <sup>**[[F-Droid](https://f-droid.org/packages/com.codedead.deadhash)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/com.codedead.deadhash)]**</sup>
 * [**droidVNC-NG**](https://github.com/bk138/droidVNC-NG) <sup>**[[F-Droid](https://f-droid.org/packages/net.christianbeier.droidvnc_ng)]**</sup>
 * [**EtchDroid**](https://github.com/EtchDroid/EtchDroid) <sup>**[[F-Droid](https://f-droid.org/packages/eu.depau.etchdroid)]**</sup>
+* [**Granular Volume: Quiet Dial**](https://github.com/Rzuss/granular-volume) <sup>**[[F-Droid](https://f-droid.org/packages/granularvolume.com)]**</sup>
 * [**HexViewer**](https://github.com/Keidan/HexViewer) <sup>**[[F-Droid](https://f-droid.org/packages/fr.ralala.hexviewer)]**</sup>
 * [**InviZible Pro**](https://github.com/Gedsh/InviZible) <sup>**[[F-Droid](https://f-droid.org/packages/pan.alexander.tordnscrypt.stable)]**</sup>
 * [**Json List**](https://github.com/SlaVcE14/JsonList) <sup>**[[F-Droid](https://f-droid.org/packages/com.sjapps.jsonlist)]**</sup>


### PR DESCRIPTION
Adding **Granular Volume: Quiet Dial**, an app that lowers audio below the hardware volume floor. It attaches a `DynamicsProcessing` effect to the global output session and applies negative gain, in seven steps from 0 to -30 dB, from a floating dial.

**Disclosure: I am the developer.** Flagging that up front rather than leaving it to be discovered.

Against the criteria in CONTRIBUTING.md:

| Criterion | |
|---|---|
| Licensed as FOSS | GPL-3.0 |
| Source code available | https://github.com/Rzuss/granular-volume |
| Keeps privacy, no ads, no spyware | No ads, no tracking, no accounts, and **no `INTERNET` permission at all**, so it cannot send anything anywhere |
| No proprietary elements | The `fdroid` product flavor contains zero Google code; the review-prompt library is scoped to the Play flavor only and replaced by a no-op stub |
| Stable | 1.3.4, in use daily |
| Actively developed | Yes |
| Documentation | https://granularvolume.com/ |
| Free of charge | Yes, no in-app purchases |

Placed in **Utilities**, alphabetically between EtchDroid and HexViewer, following the same section as the existing VolumeScroll entry. F-Droid link only, no Play Store link, per the contribution guidelines. Not on IzzyOnDroid, so no second link.

Happy to move it to a different section or reword if you would prefer.