### PR TITLE
Add Cloudflare Mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**BendyStraw**](https://codeberg.org/mm-dev/bendy-straw) <sup>**[[F-Droid](https://f-droid.org/packages/rocks.mm_dev.BendyStraw)]**</sup>
 * [**BetterCounter**](https://github.com/albertvaka/bettercounter) <sup>**[[F-Droid](https://f-droid.org/packages/org.kde.bettercounter)]**</sup>
 * [**Cams**](https://github.com/vladpen/cams) <sup>**[[F-Droid](https://f-droid.org/packages/com.vladpen.cams)]**</sup>
+* [**Cloudflare Mobile**](https://github.com/hasanzadee/cloudflare-mobile)
 * [**ConnectBot**](https://github.com/connectbot/connectbot) <sup>**[[F-Droid](https://f-droid.org/packages/org.connectbot)]**</sup>
 * [**Converter NOW**](https://github.com/ferraridamiano/ConverterNOW) <sup>**[[F-Droid](https://f-droid.org/packages/com.ferrarid.converterpro)]**</sup>
 * [**CSV Editor**](https://codeberg.org/bgrayburn/csv-editor) <sup>**[[F-Droid](https://f-droid.org/packages/tech.brianrayburn.csv_editor)]**</sup>


### PR DESCRIPTION
Adds [Cloudflare Mobile](https://github.com/hasanzadee/cloudflare-mobile) to **Utilities**, alongside the other remote-administration clients there (ConnectBot, AVNC).

It is an Android client for the Cloudflare API — zones and DNS, cache purge, zone settings, analytics, WAF rules, Workers, Pages, KV, D1, R2 and Zero Trust — plus a schema-aware explorer that builds a form for any of the 3240 API endpoints from its own schema.

Against the criteria in CONTRIBUTING.md:

- **FOSS** — Apache-2.0.
- **Source available** — everything, including the OpenAPI generator that produces the typed client.
- **Privacy** — no advertisement, no telemetry, no crash reporting, no analytics. The app talks to `api.cloudflare.com` and nothing else, plus `dash.cloudflare.com` when the user taps a button that opens the dashboard in a browser. Credentials are encrypted on device with AES-256-GCM under a PBKDF2-HMAC-SHA256 key derived from a user PIN; biometric unlock is bound to an Android Keystore key created with `setUserAuthenticationRequired`, so the check is enforced by the TEE rather than the UI. `FLAG_SECURE` is on by default and `allowBackup` is disabled.
- **No proprietary elements** — no Google Play Services, no Firebase, no closed-source dependencies.
- **Stable** — v1.0.0 released, 389 unit tests plus an on-device end-to-end suite that drives the real app through onboarding, DNS, WAF, both languages and lock/unlock.
- **Documentation** — README covers install, verification and the security model; `docs/architecture.md` covers the design.
- **Free of charge** — yes. Signed APKs on GitHub Releases with `SHA256SUMS` and a published signing certificate fingerprint.

Not yet on F-Droid or IzzyOnDroid, so the entry carries no store links; happy to open a follow-up once it is listed.

Full disclosure: I am the author, and the project is new — released today. If you would rather it had some mileage first, no objection to holding this until it does.