### PR TITLE
Add Material Prayer Times and Material Quran

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,8 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**AndBible: Bible Study**](https://github.com/AndBible/and-bible) <sup>**[[F-Droid](https://f-droid.org/packages/net.bible.android.activity)]**</sup>
 * [**Bhagavad Gita**](https://github.com/WirelessAlien/BhagavadGitaApp) <sup>**[[F-Droid](https://f-droid.org/packages/com.wirelessalien.android.bhagavadgita)]**</sup>
 * [**Dharmik**](https://github.com/shub39/Dharmik) <sup>**[[F-Droid](https://f-droid.org/packages/com.shub39.dharmik.online)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/com.shub39.dharmik.online)]**</sup>
+* [**Material Prayer Times**](https://github.com/2plus1star/material-prayer-times)
+* [**Material Quran**](https://github.com/2plus1star/material-quran)
 * [**PocketDhamma**](https://github.com/s4nj1th/pocket-dhamma) <sup>**[[F-Droid](https://f-droid.org/packages/com.s4nj1th.pocket_dhamma)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/com.s4nj1th.pocket_dhamma)]**</sup>
 
 ### • RSS Readers


### PR DESCRIPTION
Two Islamic apps for the Religion section, which currently has no prayer-times app and no Quran reader.

**Material Prayer Times** — https://github.com/2plus1star/material-prayer-times
Offline prayer times, qibla compass and Hijri date. Times are computed on device with adhan2, so the calculation needs no network access.

**Material Quran** — https://github.com/2plus1star/material-quran
Quran reader with the Uthmani text, an English translation and tajweed colouring bundled in the app. Recitation audio is optional and fetched only on request.

Both are Apache-2.0, with no ads, no analytics, no tracking and no proprietary dependencies — neither uses Google Play Services. Listed as project-page-only since neither is on F-Droid yet.

Entries are inserted alphabetically and only the Religion section is touched.