### PR TITLE
Add ABattery

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 
 ### • Battery
 
+* [**ABattery**](https://github.com/abanana84/abattery)
 * [**Battery Tool**](https://github.com/Domi04151309/BatteryTool) <sup>**[[F-Droid](https://f-droid.org/packages/io.github.domi04151309.batterytool)]**</sup>
 * [**BCL**](https://github.com/MuntashirAkon/BatteryChargeLimiter) <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/io.github.muntashirakon.bcl)]**</sup>
 * [**SaverTuner**](https://codeberg.org/s1m/savertuner) <sup>**[[F-Droid](https://f-droid.org/packages/s1m.savertuner)]**</sup>


### PR DESCRIPTION
Adds ABattery to the Battery category.

ABattery is a stable Android battery health and cycle monitor licensed under Apache-2.0. It is free of charge, actively maintained, and its source and documentation are public. The app contains no ads, analytics, account requirement, proprietary SDKs, or Internet permission.

Project: https://github.com/abanana84/abattery
Google Play: https://play.google.com/store/apps/details?id=com.abanana.abattery