### PR TITLE
Add Git Store to App Store section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Aurora Store**](https://gitlab.com/AuroraOSS/AuroraStore) <sup>**[[F-Droid](https://f-droid.org/packages/com.aurora.store)]**</sup>
 * [**IzzyOnDroid**](https://gitlab.com/sunilpaulmathew/izzyondroid) <sup>**[[F-Droid](https://f-droid.org/packages/in.sunilpaulmathew.izzyondroid)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/in.sunilpaulmathew.izzyondroid)]**</sup>
 * [**Obtainium**](https://github.com/ImranR98/Obtainium) <sup>**[[F-Droid](https://f-droid.org/packages/dev.imranr.obtainium.fdroid)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/dev.imranr.obtainium)]**</sup>
+* [**Git Store**](https://github.com/Darkmintis/Git-Store)
 * [**Komi Store**](https://github.com/kurikomi-labs/komi-store) <sup>**[[F-Droid](https://f-droid.org/packages/zed.rainxch.githubstore)]**
 * [**Zap.Store**](https://github.com/zapstore/zapstore)
 


### PR DESCRIPTION
[**Git Store**](https://github.com/Darkmintis/Git-Store) is a modern Android client for finding and installing open-source apps straight from GitHub releases. Instead of hunting through repos by hand, you get a proper store experience: trending Android projects, one-tap APK install, and update alerts for the apps you already have.

### What it does

- Discovers trending and popular GitHub repos that actually ship Android releases
- Installs APKs in one tap, directly from the latest release
- Tracks installed apps and notifies you when a new version is out
- Search and filter by language and category
- Full repo pages with releases, changelogs, and project details
- Star and save favorites, with GitHub OAuth for a personalized feed

Apache 2.0, source and APKs on GitHub: https://github.com/Darkmintis/Git-Store