### PR TITLE
Add KashCal to Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Birday**](https://github.com/m-i-n-a-r/birday) <sup>**[[F-Droid](https://f-droid.org/packages/com.minar.birday)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/com.minar.birday)]**</sup>
 * [**Etar**](https://github.com/Etar-Group/Etar-Calendar) <sup>**[[F-Droid](https://f-droid.org/packages/ws.xsoh.etar)]**</sup>
 * [**Fossify Calendar**](https://github.com/FossifyOrg/Calendar) <sup>**[[F-Droid](https://f-droid.org/packages/org.fossify.calendar)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/org.fossify.calendar)]**</sup>
+* [**KashCal**](https://github.com/KashCal/KashCal) <sup>**[[F-Droid](https://f-droid.org/packages/org.onekash.kashcal)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/org.onekash.kashcal)]**</sup>
 * [**Tuta Calendar**](https://github.com/tutao/tutanota) <sup>**[[F-Droid](https://f-droid.org/packages/de.tutao.calendar)]**</sup>
 
 ### • Call Blocker & Spam Filter


### PR DESCRIPTION
Adds **KashCal** to the Calendar section (alphabetical order, between Fossify Calendar and Tuta Calendar).

KashCal is an offline-first Android calendar with iCloud/CalDAV sync, ICS subscriptions, contact birthdays, full-text search, recurring events and home-screen widgets.

Inclusion criteria:
- **FOSS / source available:** Apache-2.0 — https://github.com/KashCal/KashCal
- **Privacy:** no ads, no analytics, no telemetry, no account
- **On F-Droid:** https://f-droid.org/packages/org.onekash.kashcal
- **On IzzyOnDroid:** https://apt.izzysoft.de/packages/org.onekash.kashcal (no anti-features flagged)
- **Actively maintained**, with documentation / website: https://kashcal.onekash.org
- **Free of charge**

Disclosure: I am the developer of KashCal.
