### PR TITLE
Add OpenTasker to Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 * [**Automation**](https://git.server47.de/jens/Automation) <sup>**[[F-Droid](https://f-droid.org/packages/com.jens.automation2)]**</sup>
 * [**Dicio**](https://github.com/Stypox/dicio-android) <sup>**[[F-Droid](https://f-droid.org/packages/org.stypox.dicio)]**</sup>
 * [**Home Assistant**](https://github.com/home-assistant/android) <sup>**[[F-Droid](https://f-droid.org/packages/io.homeassistant.companion.android.minimal)]**</sup>
+* [**OpenTasker**](https://github.com/SysAdminDoc/OpenTasker)
 * [**Smart AutoClicker**](https://github.com/Nain57/Smart-AutoClicker) <sup>**[[F-Droid](https://f-droid.org/packages/com.buzbuz.smartautoclicker)]**</sup>
 
 ### • Backup


### PR DESCRIPTION
Adds [OpenTasker](https://github.com/SysAdminDoc/OpenTasker) to the Automation section, alphabetically between Home Assistant and Smart AutoClicker.

OpenTasker is a Tasker-style automation app for Android. Profiles watch device contexts (time, location, network, battery, NFC, calendar, plugin conditions) and run tasks built from a catalog of built-in actions.

Against the listing criteria:

- MIT licensed, source on GitHub
- No ads, no telemetry, no crash reporting, no account. There is no analytics SDK in the dependency graph and no Google Play Services dependency
- No proprietary components. Location works through the platform providers rather than Play Services, so the FOSS build has no non-free path
- Actively developed, currently at v0.2.87 with a changelog and roadmap in the repo
- Free of charge
- README documents install, permissions and the action catalog

It has INTERNET, since HTTP request and download actions are part of what an automation app does, but nothing in the app phones home.

It's not on F-Droid or IzzyOnDroid yet, so the entry links the project page only, as the contributing guide allows.
