### PR TITLE
Add spoo.me (URL Manipulation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 
 * [**Leon**](https://github.com/svenjacobs/leon) <sup>**[[F-Droid](https://f-droid.org/packages/com.svenjacobs.app.leon)]**</sup> <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/com.svenjacobs.app.leon)]**</sup>
 * [**LinkSheet**](https://github.com/LinkSheet/LinkSheet) <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/fe.linksheet)]**</sup>
+* [**spoo.me**](https://github.com/spoo-me/spoo-android)
 * [**Tarnhelm**](https://github.com/lz233/Tarnhelm) <sup>**[[F-Droid](https://f-droid.org/packages/cn.ac.lz233.tarnhelm)]**</sup>
 * [**Untracker**](https://github.com/zhanghai/Untracker) <sup>**[[F-Droid](https://f-droid.org/packages/me.zhanghai.android.untracker)]**</sup>
 * [**UntrackMe**](https://framagit.org/tom79/nitterizeme) <sup>**[[F-Droid](https://f-droid.org/packages/app.fedilab.nitterizeme)]**</sup>


### PR DESCRIPTION
Adds spoo.me, the official Android client for the spoo.me URL shortener, under URL Manipulation.

Criteria:

- AGPL-3.0, full source at https://github.com/spoo-me/spoo-android (the whole stack, server included, is open source under github.com/spoo-me)
- No ads, no trackers, no proprietary dependencies
- Stable and actively developed, releases signed and published from CI
- Documentation in the repository readme; the service is documented at https://docs.spoo.me
- Free of charge

Project page only for now; an IzzyOnDroid inclusion request is in progress, happy to add the link once it lands.