### PR TITLE
Add Blazify

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ A list of **Free** and **Open Source Software** ***(FOSS)*** for **Android** –
 ### • Music & Radio Streaming Player
 
 * [**ArchiveTune**](https://github.com/koiverse/ArchiveTune) <sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/moe.koiverse.archivetune)]**</sup>
+* [**Blazify**](https://github.com/rajendra7169/blazify)
 * [**Bloomee**](https://github.com/HemantKArya/BloomeeTunes)<sup>**[[IzzyOnDroid](https://apt.izzysoft.de/packages/ls.bloomee.musicplayer)]**</sup>
 * [**Deutsia Radio**](https://github.com/deutsia/deutsia-radio)<sup>**[[F-Droid](https://f-droid.org/packages/com.opensource.i2pradio)]**</sup>
 * [**Echo Music**](https://github.com/EchoMusicApp/Echo-Music)


### PR DESCRIPTION
Adding Blazify, a music player I develop.

* Source: https://github.com/rajendra7169/blazify
* License: GPL-3.0
* No advertisement, no analytics, no tracking libraries
* No proprietary components — the only Google dependency (play-services-cast-framework) is gmsImplementation and is not in the foss build
* Free of charge, actively developed, documented in the README

It is a fork of Metrolist (already listed), which derives from InnerTune. The streaming core comes from those; the interface, theming, updater and lyrics work are mine.

An IzzyOnDroid inclusion request is open (IzzyOnDroid/repodata#524) — I will send a follow-up PR to add the badge once it lands.